### PR TITLE
fixed bug with ScaleSet

### DIFF
--- a/src/JointModelPersonalization/KinematicCalibration/functions/adjustBodyScaling.m
+++ b/src/JointModelPersonalization/KinematicCalibration/functions/adjustBodyScaling.m
@@ -42,7 +42,8 @@ state = initializeState(model);
 scaleSet = org.opensim.modeling.ScaleSet();
 scale = org.opensim.modeling.Scale();
 scale.setSegmentName(bodyName);
-scale.setScaleFactors(org.opensim.modeling.Vec3(value));
+scale.setScaleFactors(org.opensim.modeling.Vec3(value / ...
+    getScalingParameterValue(model, bodyName)));
 scale.setApply(true);
 scaleSet.cloneAndAppend(scale);
 model.scale(state, scaleSet, true, -1.0);


### PR DESCRIPTION
the `setScaleFactor()` fn scales the scaled value by the value rather than setting that value as the new scale value.

I.E: if you want the scale to be 1.2 and the current scale value is 1.1, then setting a value of 1.2 for `setScaleFactor()` causes the body to scale to 1.32. This effect is less noticeable at smaller scale values.

Closes #231 